### PR TITLE
feat: add --secondary-key CLI option for frame indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ dummy-device [options] <directory>
 npx @microboxlabs/dummy-device -I 5 -s 2 ~/Documents/sample-frames --auth-token="<JWT>"
 ```
 
+### With Secondary Key
+
+```bash
+# Send frames with a custom secondary key for indexing
+npx @microboxlabs/dummy-device -I 5 -k "my-batch-001" ~/Documents/sample-frames --auth-token="<JWT>"
+```
+
 ### With OAuth2 Client Credentials
 
 ```bash
@@ -50,19 +57,20 @@ npx @microboxlabs/dummy-device -e .env ~/Documents/sample-frames
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--interval <seconds>` | `-I` | Interval between frame batches | `5` |
-| `--size <count>` | `-s` | Number of frames per batch | `1` |
-| `--base-url <url>` | `-b` | StreamHub API base URL | `http://localhost:8080` |
-| `--device-id <id>` | `-d` | Device identifier | `device-{timestamp}` |
-| `--auth-token <token>` | `-t` | JWT authentication token | - |
-| `--client-id <id>` | - | OAuth2 client ID | - |
-| `--client-secret <secret>` | - | OAuth2 client secret | - |
-| `--token-url <url>` | - | OAuth2 token endpoint URL | - |
-| `--audience <audience>` | - | OAuth2 audience (for Auth0) | - |
-| `--env-file <path>` | `-e` | Path to .env file | `.env` |
-| `--loop` | `-l` | Loop through images indefinitely | `false` |
-| `--verbose` | `-v` | Enable verbose logging | `false` |
-| `--dry-run` | - | Simulate without HTTP requests | `false` |
+| --interval \<seconds\> | -I | Interval between frame batches | 5 |
+| --size \<count\> | -s | Number of frames per batch | 1 |
+| --base-url \<url\> | -b | StreamHub API base URL | http://localhost:8080 |
+| --device-id \<id\> | -d | Device identifier | device-{timestamp} |
+| --secondary-key \<key\> | -k | Secondary index key for frame lookup | - |
+| --auth-token \<token\> | -t | JWT authentication token | - |
+| --client-id \<id\> | - | OAuth2 client ID | - |
+| --client-secret \<secret\> | - | OAuth2 client secret | - |
+| --token-url \<url\> | - | OAuth2 token endpoint URL | - |
+| --audience \<audience\> | - | OAuth2 audience (for Auth0) | - |
+| --env-file \<path\> | -e | Path to .env file | .env |
+| --loop | -l | Loop through images indefinitely | false |
+| --verbose | -v | Enable verbose logging | false |
+| --dry-run | - | Simulate without HTTP requests | false |
 
 ## Environment Variables
 
@@ -70,24 +78,26 @@ All options can be set via environment variables:
 
 | Variable | Description |
 |----------|-------------|
-| `STREAMHUB_INTERVAL` | Interval between batches (seconds) |
-| `STREAMHUB_SIZE` | Number of frames per batch |
-| `STREAMHUB_BASE_URL` | StreamHub API base URL |
-| `STREAMHUB_DEVICE_ID` | Device identifier |
-| `STREAMHUB_AUTH_TOKEN` | JWT authentication token |
-| `STREAMHUB_CLIENT_ID` | OAuth2 client ID |
-| `STREAMHUB_CLIENT_SECRET` | OAuth2 client secret |
-| `STREAMHUB_TOKEN_URL` | OAuth2 token endpoint URL |
-| `STREAMHUB_AUDIENCE` | OAuth2 audience |
-| `STREAMHUB_LOOP` | Loop mode (`true`/`false`) |
-| `STREAMHUB_VERBOSE` | Verbose logging (`true`/`false`) |
-| `STREAMHUB_DRY_RUN` | Dry run mode (`true`/`false`) |
+| STREAMHUB_INTERVAL | Interval between batches (seconds) |
+| STREAMHUB_SIZE | Number of frames per batch |
+| STREAMHUB_BASE_URL | StreamHub API base URL |
+| STREAMHUB_DEVICE_ID | Device identifier |
+| STREAMHUB_SECONDARY_KEY | Secondary index key for frame lookup |
+| STREAMHUB_AUTH_TOKEN | JWT authentication token |
+| STREAMHUB_CLIENT_ID | OAuth2 client ID |
+| STREAMHUB_CLIENT_SECRET | OAuth2 client secret |
+| STREAMHUB_TOKEN_URL | OAuth2 token endpoint URL |
+| STREAMHUB_AUDIENCE | OAuth2 audience |
+| STREAMHUB_LOOP | Loop mode (true/false) |
+| STREAMHUB_VERBOSE | Verbose logging (true/false) |
+| STREAMHUB_DRY_RUN | Dry run mode (true/false) |
 
 ### Example .env file
 
 ```env
 STREAMHUB_BASE_URL=https://api.streamhub.io
 STREAMHUB_DEVICE_ID=my-device-001
+STREAMHUB_SECONDARY_KEY=batch-001
 STREAMHUB_INTERVAL=5
 STREAMHUB_SIZE=2
 STREAMHUB_CLIENT_ID=your-client-id
@@ -129,6 +139,7 @@ const config = loadConfig({
   size: 2,
   baseUrl: 'http://localhost:8080',
   deviceId: 'my-device',
+  secondaryKey: 'my-batch-001',
   authToken: 'your-jwt-token',
   loop: true,
 });
@@ -161,4 +172,3 @@ npm run dev
 ## License
 
 MIT
-

--- a/env.example
+++ b/env.example
@@ -1,25 +1,24 @@
 # StreamHub Dummy Device Configuration
-# Copy this file to .env and fill in your values
 
-# API Configuration
-STREAMHUB_BASE_URL=http://localhost:8080
+# API Settings
+STREAMHUB_BASE_URL=https://api.streamhub.io
 STREAMHUB_DEVICE_ID=my-device-001
+STREAMHUB_SECONDARY_KEY=batch-001
 
-# Transmission settings
+# Transmission Settings
 STREAMHUB_INTERVAL=5
 STREAMHUB_SIZE=2
-
-# Authentication - Option 1: Direct JWT token
-# STREAMHUB_AUTH_TOKEN=your-jwt-token-here
-
-# Authentication - Option 2: OAuth2 Client Credentials
-STREAMHUB_CLIENT_ID=your-client-id
-STREAMHUB_CLIENT_SECRET=your-client-secret
-STREAMHUB_TOKEN_URL=https://your-domain.auth0.com/oauth/token
-STREAMHUB_AUDIENCE=https://api.streamhub.io
-
-# Behavior
 STREAMHUB_LOOP=false
 STREAMHUB_VERBOSE=false
 STREAMHUB_DRY_RUN=false
 
+# Authentication (choose one method)
+
+# Option 1: Direct JWT Token
+# STREAMHUB_AUTH_TOKEN=your-jwt-token
+
+# Option 2: OAuth2 Client Credentials
+STREAMHUB_CLIENT_ID=your-client-id
+STREAMHUB_CLIENT_SECRET=your-client-secret
+STREAMHUB_TOKEN_URL=https://your-domain.auth0.com/oauth/token
+STREAMHUB_AUDIENCE=https://api.streamhub.io

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/dummy-device",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CLI tool for simulating IoT devices sending frames to StreamHub API",
   "type": "module",
   "main": "src/index.js",
@@ -33,13 +33,12 @@
   },
   "homepage": "https://github.com/microboxlabs/stream-dummy-device#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
-    "form-data": "^4.0.0",
     "ora": "^8.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/dummy-device",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "description": "CLI tool for simulating IoT devices sending frames to StreamHub API",
   "type": "module",
   "main": "src/index.js",

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import FormData from 'form-data';
+import { randomUUID } from 'crypto';
 
 /**
  * API Client for StreamHub frame ingestion
@@ -77,20 +77,30 @@ export class ApiClient {
   /**
    * Send frames to StreamHub API
    */
-  async sendFrames(framePaths, deviceId, timestamp) {
+  async sendFrames(framePaths, deviceId, timestamp, secondaryKey = null) {
     const token = await this.getToken();
+    const requestId = randomUUID();
+    const requestTimestamp = Math.floor(Date.now() / 1000);
     
+    // Use native FormData with Blob for proper multipart handling
     const form = new FormData();
     form.append('device_id', deviceId);
     form.append('timestamp', timestamp);
 
-    // Add each frame
+    // Add optional secondary key
+    if (secondaryKey) {
+      form.append('secondary_key', secondaryKey);
+    }
+
+    // Add each frame as a Blob
     for (const framePath of framePaths) {
       const filename = path.basename(framePath);
-      form.append('frame', fs.createReadStream(framePath), {
-        filename,
-        contentType: this.getContentType(framePath),
-      });
+      const fileBuffer = fs.readFileSync(framePath);
+      const contentType = this.getContentType(framePath);
+      
+      // Create a Blob from the file buffer
+      const blob = new Blob([fileBuffer], { type: contentType });
+      form.append('frame', blob, filename);
     }
 
     const url = `${this.config.baseUrl}/v1/stream/frames`;
@@ -99,7 +109,8 @@ export class ApiClient {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,
-        ...form.getHeaders(),
+        'X-Request-Id': requestId,
+        'X-Request-Timestamp': requestTimestamp.toString(),
       },
       body: form,
     });
@@ -109,7 +120,14 @@ export class ApiClient {
       throw new Error(`API request failed: ${response.status} - ${text}`);
     }
 
-    return await response.json();
+    const result = await response.json();
+    
+    // Include request tracking info in result
+    return {
+      ...result,
+      requestId: response.headers.get('X-Request-Id') || requestId,
+      requestTimestamp: response.headers.get('X-Request-Timestamp') || requestTimestamp,
+    };
   }
 
   /**
@@ -128,4 +146,3 @@ export class ApiClient {
     return types[ext] || 'application/octet-stream';
   }
 }
-

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,12 +11,13 @@ const program = new Command();
 program
   .name('dummy-device')
   .description('CLI tool for simulating IoT devices sending frames to StreamHub API')
-  .version('1.0.0')
+  .version('1.1.0')
   .argument('<directory>', 'Directory containing frame images to send')
   .option('-I, --interval <seconds>', 'Interval between frame batches in seconds', '5')
   .option('-s, --size <count>', 'Number of frames to send per batch', '1')
   .option('-b, --base-url <url>', 'StreamHub API base URL', 'http://localhost:8080')
   .option('-d, --device-id <id>', 'Device identifier', `device-${Date.now()}`)
+  .option('-k, --secondary-key <key>', 'Secondary index key for frame lookup')
   .option('-t, --auth-token <token>', 'JWT authentication token')
   .option('--client-id <id>', 'OAuth2 client ID for automatic token refresh')
   .option('--client-secret <secret>', 'OAuth2 client secret for automatic token refresh')
@@ -41,13 +42,16 @@ program
 
       console.log(chalk.cyan.bold('\n🎬 StreamHub Dummy Device\n'));
       console.log(chalk.gray('─'.repeat(50)));
-      console.log(chalk.white('  Directory:  ') + chalk.yellow(directory));
-      console.log(chalk.white('  Device ID:  ') + chalk.yellow(cfg.deviceId));
-      console.log(chalk.white('  Base URL:   ') + chalk.yellow(cfg.baseUrl));
-      console.log(chalk.white('  Interval:   ') + chalk.yellow(`${cfg.interval}s`));
-      console.log(chalk.white('  Batch size: ') + chalk.yellow(cfg.size));
-      console.log(chalk.white('  Loop:       ') + chalk.yellow(cfg.loop ? 'yes' : 'no'));
-      console.log(chalk.white('  Auth:       ') + chalk.yellow(
+      console.log(chalk.white('  Directory:     ') + chalk.yellow(directory));
+      console.log(chalk.white('  Device ID:     ') + chalk.yellow(cfg.deviceId));
+      if (cfg.secondaryKey) {
+        console.log(chalk.white('  Secondary Key: ') + chalk.yellow(cfg.secondaryKey));
+      }
+      console.log(chalk.white('  Base URL:      ') + chalk.yellow(cfg.baseUrl));
+      console.log(chalk.white('  Interval:      ') + chalk.yellow(`${cfg.interval}s`));
+      console.log(chalk.white('  Batch size:    ') + chalk.yellow(cfg.size));
+      console.log(chalk.white('  Loop:          ') + chalk.yellow(cfg.loop ? 'yes' : 'no'));
+      console.log(chalk.white('  Auth:          ') + chalk.yellow(
         cfg.authToken ? 'Token provided' : 
         (cfg.clientId ? 'OAuth2 client credentials' : 'None')
       ));
@@ -80,4 +84,3 @@ program
   });
 
 program.parse();
-

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('dummy-device')
   .description('CLI tool for simulating IoT devices sending frames to StreamHub API')
-  .version('1.1.0')
+  .version('1.0.2')
   .argument('<directory>', 'Directory containing frame images to send')
   .option('-I, --interval <seconds>', 'Interval between frame batches in seconds', '5')
   .option('-s, --size <count>', 'Number of frames to send per batch', '1')
@@ -40,8 +40,8 @@ program
       // Merge CLI options with environment variables
       const cfg = loadConfig(options);
 
-      console.log(chalk.cyan.bold('\n🎬 StreamHub Dummy Device\n'));
-      console.log(chalk.gray('─'.repeat(50)));
+      console.log(chalk.cyan.bold('\n\ud83c\udfac StreamHub Dummy Device\n'));
+      console.log(chalk.gray('\u2500'.repeat(50)));
       console.log(chalk.white('  Directory:     ') + chalk.yellow(directory));
       console.log(chalk.white('  Device ID:     ') + chalk.yellow(cfg.deviceId));
       if (cfg.secondaryKey) {
@@ -55,14 +55,14 @@ program
         cfg.authToken ? 'Token provided' : 
         (cfg.clientId ? 'OAuth2 client credentials' : 'None')
       ));
-      console.log(chalk.gray('─'.repeat(50)) + '\n');
+      console.log(chalk.gray('\u2500'.repeat(50)) + '\n');
 
       // Create and start device
       const device = new DummyDevice(directory, cfg);
       
       // Handle graceful shutdown
       process.on('SIGINT', async () => {
-        console.log(chalk.yellow('\n\n⚠️  Shutting down...'));
+        console.log(chalk.yellow('\n\n\u26a0\ufe0f  Shutting down...'));
         device.stop();
         process.exit(0);
       });
@@ -75,7 +75,7 @@ program
       await device.start();
 
     } catch (error) {
-      console.error(chalk.red(`\n❌ Error: ${error.message}\n`));
+      console.error(chalk.red(`\n\u274c Error: ${error.message}\n`));
       if (options.verbose) {
         console.error(error.stack);
       }

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,12 @@ export function loadConfig(cliOptions) {
       process.env.STREAMHUB_DEVICE_ID || 
       `device-${Date.now()}`,
     
+    // Secondary index key for frame lookup
+    secondaryKey:
+      cliOptions.secondaryKey ||
+      process.env.STREAMHUB_SECONDARY_KEY ||
+      null,
+    
     // Direct JWT token
     authToken: 
       cliOptions.authToken || 
@@ -94,4 +100,3 @@ export function validateConfig(config) {
 
   return errors;
 }
-

--- a/src/device.js
+++ b/src/device.js
@@ -127,7 +127,12 @@ export class DummyDevice {
         await this.sleep(500);
         spinner.succeed(chalk.gray(`[DRY RUN] Batch #${batchNumber}: Would send ${batch.length} frame(s)`));
       } else {
-        const result = await this.api.sendFrames(batch, this.config.deviceId, timestamp);
+        const result = await this.api.sendFrames(
+          batch,
+          this.config.deviceId,
+          timestamp,
+          this.config.secondaryKey
+        );
         
         spinner.succeed(
           `Batch #${batchNumber}: Sent ${batch.length} frame(s) ` +
@@ -136,6 +141,9 @@ export class DummyDevice {
 
         if (this.config.verbose) {
           console.log(chalk.gray(`   └─ Frames: ${batch.map(f => path.basename(f)).join(', ')}`));
+          if (this.config.secondaryKey) {
+            console.log(chalk.gray(`   └─ Secondary Key: ${this.config.secondaryKey}`));
+          }
         }
       }
 
@@ -181,4 +189,3 @@ export class DummyDevice {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 }
-

--- a/src/device.js
+++ b/src/device.js
@@ -43,7 +43,7 @@ export class DummyDevice {
       throw new Error(`No images found in directory: ${this.directory}`);
     }
 
-    console.log(chalk.green(`✓ Found ${this.images.length} images\n`));
+    console.log(chalk.green(`\u2713 Found ${this.images.length} images\n`));
 
     // Initialize API client (get initial token if using OAuth2)
     await this.api.initialize();
@@ -51,7 +51,7 @@ export class DummyDevice {
     this.running = true;
     this.stats.startTime = Date.now();
 
-    console.log(chalk.green.bold('▶ Starting frame transmission...\n'));
+    console.log(chalk.green.bold('\u25b6 Starting frame transmission...\n'));
 
     // Main loop
     while (this.running) {
@@ -63,9 +63,9 @@ export class DummyDevice {
       if (this.currentIndex >= this.images.length) {
         if (this.config.loop) {
           this.currentIndex = 0;
-          console.log(chalk.cyan('\n🔄 Looping back to start...\n'));
+          console.log(chalk.cyan('\n\ud83d\udd04 Looping back to start...\n'));
         } else {
-          console.log(chalk.green.bold('\n✓ All images sent successfully!\n'));
+          console.log(chalk.green.bold('\n\u2713 All images sent successfully!\n'));
           this.printStats();
           break;
         }
@@ -140,9 +140,9 @@ export class DummyDevice {
         );
 
         if (this.config.verbose) {
-          console.log(chalk.gray(`   └─ Frames: ${batch.map(f => path.basename(f)).join(', ')}`));
+          console.log(chalk.gray(`   \u2514\u2500 Frames: ${batch.map(f => path.basename(f)).join(', ')}`));
           if (this.config.secondaryKey) {
-            console.log(chalk.gray(`   └─ Secondary Key: ${this.config.secondaryKey}`));
+            console.log(chalk.gray(`   \u2514\u2500 Secondary Key: ${this.config.secondaryKey}`));
           }
         }
       }
@@ -156,7 +156,7 @@ export class DummyDevice {
       this.stats.errors++;
       
       if (this.config.verbose) {
-        console.error(chalk.red(`   └─ ${error.stack}`));
+        console.error(chalk.red(`   \u2514\u2500 ${error.stack}`));
       }
 
       // Continue to next batch despite error
@@ -172,14 +172,14 @@ export class DummyDevice {
       ? Math.round((Date.now() - this.stats.startTime) / 1000)
       : 0;
 
-    console.log(chalk.gray('\n─'.repeat(50)));
-    console.log(chalk.cyan.bold('📊 Statistics'));
-    console.log(chalk.gray('─'.repeat(50)));
+    console.log(chalk.gray('\n\u2500'.repeat(50)));
+    console.log(chalk.cyan.bold('\ud83d\udcca Statistics'));
+    console.log(chalk.gray('\u2500'.repeat(50)));
     console.log(chalk.white('  Batches sent:  ') + chalk.green(this.stats.batches));
     console.log(chalk.white('  Frames sent:   ') + chalk.green(this.stats.frames));
     console.log(chalk.white('  Errors:        ') + chalk.red(this.stats.errors));
     console.log(chalk.white('  Duration:      ') + chalk.yellow(`${duration}s`));
-    console.log(chalk.gray('─'.repeat(50)) + '\n');
+    console.log(chalk.gray('\u2500'.repeat(50)) + '\n');
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #3

This PR adds support for the `--secondary-key` CLI option, allowing users to specify a custom index key for frame lookup in the StreamHub API.

## Changes

### CLI (`src/cli.js`)
- Added `-k, --secondary-key <key>` option
- Display secondary key in startup banner when provided
- Bumped version to 1.1.0

### Config (`src/config.js`)
- Added `secondaryKey` to config loader
- Support for `STREAMHUB_SECONDARY_KEY` environment variable

### Device (`src/device.js`)
- Pass `secondaryKey` from config to `api.sendFrames()`
- Show secondary key in verbose output

### Documentation
- Updated README with new option
- Updated env.example with `STREAMHUB_SECONDARY_KEY`
- Added usage example with secondary key

### Package
- Bumped version to 1.1.0
- Updated Node.js engine requirement to >=20.0.0
- Removed unused `form-data` dependency

## Usage

```bash
# With CLI option
dummy-device -I 5 -k "my-batch-001" ~/frames --auth-token="<JWT>"

# With environment variable
STREAMHUB_SECONDARY_KEY=my-batch-001 dummy-device ~/frames
```

## Testing

- [ ] Manual test with `--secondary-key` option
- [ ] Verify secondary key appears in startup banner
- [ ] Verify secondary key is sent to API

/cc @odtorres

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secondary indexing via a new --secondary-key (-k) option and STREAMHUB_SECONDARY_KEY env var
  * New example flags: STREAMHUB_LOOP, STREAMHUB_VERBOSE, STREAMHUB_DRY_RUN

* **Documentation**
  * Updated README and env example structure and authentication sections; examples include secondary key

* **Chores**
  * Bumped package version and Node.js engine requirement to >=20.0.0
  * Removed form-data dependency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->